### PR TITLE
feat: added plausible analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -150,5 +150,11 @@ module.exports = {
         ],
       },
     },
+    {
+      resolve: `gatsby-plugin-plausible`,
+      options: {
+        domain: `blog.amestofortytwo.com`,
+      },
+    },
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@raae/gatsby-remark-oembed": "^0.3.1",
         "gatsby": "^4.12.1",
         "gatsby-plugin-feed": "^4.11.1",
+        "gatsby-plugin-plausible": "^0.0.7",
         "gatsby-plugin-sitemap": "^5.11.1",
         "gatsby-remark-responsive-iframe": "^5.11.0",
         "react": "^17.0.1",
@@ -10052,6 +10053,45 @@
       },
       "peerDependencies": {
         "gatsby": "^4.0.0-next"
+      }
+    },
+    "node_modules/gatsby-plugin-plausible": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-plausible/-/gatsby-plugin-plausible-0.0.7.tgz",
+      "integrity": "sha512-pWCXsrWal8lWMmZ1wJ2dolbwZZR1CZU1LVR/K1rYC8NeA+uqTLY8h3uH3hFgP5n8jmRRenOSJ9SjWM9OIdCjOA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "minimatch": "3.0.4",
+        "react": "^16.13.1"
+      },
+      "peerDependencies": {
+        "gatsby": ">=2.0.0",
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-plausible/node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/gatsby-plugin-plausible/node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/gatsby-plugin-postcss": {
@@ -27512,6 +27552,36 @@
         "gatsby-telemetry": "^3.25.0",
         "globby": "^11.1.0",
         "lodash": "^4.17.21"
+      }
+    },
+    "gatsby-plugin-plausible": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-plausible/-/gatsby-plugin-plausible-0.0.7.tgz",
+      "integrity": "sha512-pWCXsrWal8lWMmZ1wJ2dolbwZZR1CZU1LVR/K1rYC8NeA+uqTLY8h3uH3hFgP5n8jmRRenOSJ9SjWM9OIdCjOA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "minimatch": "3.0.4",
+        "react": "^16.13.1"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "react": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        }
       }
     },
     "gatsby-plugin-postcss": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@raae/gatsby-remark-oembed": "^0.3.1",
     "gatsby": "^4.12.1",
     "gatsby-plugin-feed": "^4.11.1",
+    "gatsby-plugin-plausible": "^0.0.7",
     "gatsby-plugin-sitemap": "^5.11.1",
     "gatsby-remark-responsive-iframe": "^5.11.0",
     "react": "^17.0.1",


### PR DESCRIPTION
We'd like to use Plausible Analytics to view site trends and metrics and such, but not track any user-identifiable details. Plausible offers one of the best GatsbyJS integrations to do Analytics in a privacy-centric way. 

Ping me if you want admin access to the Plausible dashboard.

Signed-off-by: Alexander Grimstad <alexander.grimstad@amesto.no>