### PR TITLE
fix: removing trailing slashes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,6 +2,7 @@ const path = require("path")
 
 module.exports = {
   // pathPrefix: `/`,
+  trailingSlash: "never",
   siteMetadata: {
     title: `Amesto Fortytwo Blog`,
     name: `Fortytwo`,


### PR DESCRIPTION
Noticed in analytics that "page" and "page/" is treated as two separate entries, which it should - But it does spread / obscure the metrics...

After reading up on the concept of trailing slashes, and understanding how GatsbyJS handles it, I'm ready to suggest that we do as Github Pages, and enforces removing trailing slashes to get cleaner analytics data.

Relevant resources:
- https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash
- https://github.com/gatsbyjs/gatsby/discussions/34205

Signed-off-by: Alexander Grimstad <alexander.grimstad@amesto.no>