### PR TITLE
fix: changed trailingSlash to always

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,7 @@ const path = require("path")
 
 module.exports = {
   // pathPrefix: `/`,
-  trailingSlash: "never",
+  trailingSlash: "always",
   siteMetadata: {
     title: `Amesto Fortytwo Blog`,
     name: `Fortytwo`,


### PR DESCRIPTION
Ammending #14 and changing trailingSlash to "always" because most browsers actually adds a trailing slash onto the request when a page is being refreshed - So in an effort to get clean metrics / analytics, I suggest that we have it on for all pages... 

Signed-off-by: Alexander Grimstad <alexander.grimstad@amesto.no>